### PR TITLE
Fix manifest include

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 global-include *.html
-global-include *.css
 include pbshm/ietools/files/*.json
 exclude pbshm/__init__.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-global-include *.html
+recursive-include pbshm *.html
 include pbshm/ietools/files/*.json
 exclude pbshm/__init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbshm-ie-toolbox"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     { name = "Dan Brennan", email = "d.s.brennan@sheffield.ac.uk" }
 ]


### PR DESCRIPTION
The manifest was inadvertently including HTML files from installed packages, instead of just the PBSHM namespace. The manifest was also including CSS files; however, there is no CSS files within this module.